### PR TITLE
add printf.h header for toolchains without stdio.h

### DIFF
--- a/src/include/libmspprintf/printf.h
+++ b/src/include/libmspprintf/printf.h
@@ -1,0 +1,6 @@
+#ifndef LIBMSPPRINTF_PRINTF_H
+#define LIBMSPPRINTF_PRINTF_H
+
+int printf(const char *, ...);
+
+#endif // LIBMSPPRINTF_PRINTF_H


### PR DESCRIPTION
Harmless (unused) for apps that wish to include stdio.h from
their toolchain that does have it.